### PR TITLE
Vc/docker dataengineering sqlmesh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -168,4 +168,4 @@
 	url = https://github.com/lsc-sde/iac-flux-keycloak.git
 [submodule "docker/dataengineering-sqlmesh-notebook"]
 	path = docker/dataengineering-sqlmesh-notebook
-	url = https://github.com/lsc-sde/dataengineering-sqlmesh-notebook
+	url = https://github.com/lsc-sde/docker-dataengineering-sqlmesh-notebook

--- a/.gitmodules
+++ b/.gitmodules
@@ -166,3 +166,6 @@
 [submodule "products/sde-3rd-party/keycloak/iac-flux-keycloak"]
 	path = products/sde-3rd-party/keycloak/iac-flux-keycloak
 	url = https://github.com/lsc-sde/iac-flux-keycloak.git
+[submodule "docker/dataengineering-sqlmesh-notebook"]
+	path = docker/dataengineering-sqlmesh-notebook
+	url = https://github.com/lsc-sde/dataengineering-sqlmesh-notebook


### PR DESCRIPTION
This PR adds a new git submodule for a repo for a custom docker image for data engineering. The image has been tested locally and has built/pushed successfully to https://hub.docker.com/r/lscsde/dataengineering-sqlmesh-notebook/tags.

However, an earlier attempt where this repo was forked from https://github.com/lsc-sde/docker-datascience-notebook-default resulted in wrong version number being assigned to the docker image that was built and pushed (0.1.23) - could this be deleted please?